### PR TITLE
Fix min/max compilation errors

### DIFF
--- a/src/NBHX711.cpp
+++ b/src/NBHX711.cpp
@@ -10,7 +10,8 @@ NBHX711::NBHX711(byte data, byte clock, byte depth, byte gain) :
 	histBuffer(NULL),
 	curr(0)
 {
-	histSize = 3 * min(max(depth, 6), 255/3);
+	histSize =
+		3 * min(max(depth, static_cast<byte>(6)), static_cast<byte>(255 / 3));
 	histBuffer = new byte[histSize];
 	if (!histBuffer) {
 		histSize = 0;


### PR DESCRIPTION
Cast int literals to char to match the other argument's type and prevent this compilation error in PlatformIO: `NBHX711.cpp:13:60: error: no matching function for call to 'min(const unsigned char&, int)'`